### PR TITLE
Grammatical connection error

### DIFF
--- a/de_de.nhloc
+++ b/de_de.nhloc
@@ -3204,7 +3204,7 @@
 		},
 		{
 			"id": "licenseinfo.personal.multipleecomputers",
-			"txt": "Sie verwenden eine persönliche Lizenz. Es kann auf bis zu %1 Computern aktiviert werden, aber PTGui darf nur von %0 auf diesen Computern verwendet werden."
+			"txt": "Sie verwenden eine persönliche Lizenz. PTGUi kann auf bis zu %1 Computern aktiviert werden, aber es darf nur von %0 auf diesen Computern verwendet werden."
 		},
 		{
 			"id": "licenseinfo.company.singlecomputer",


### PR DESCRIPTION
"Es" cannot refer to the previous "license" but to "PTGUi".
Therefore, in the next sentence, you cannot start with "Es". Otherwise it would have to be "Sie" (the license).

3202  			"id": "licenseinfo.personal.singlecomputer",
			"txt": "Sie verwenden eine persönliche Lizenz für einen einzelnen Computer. PTGui darf nur von %0 verwendet werden."